### PR TITLE
fix Stray end tag meta

### DIFF
--- a/lib/seorel/helper/base.rb
+++ b/lib/seorel/helper/base.rb
@@ -23,8 +23,8 @@ module Seorel
 
       alias_method :h, :helpers
 
-      # def h.content_tag(*args)
-      #   ActionView::Helpers::TagHelper.h.content_tag(*args)
+      # def h.tag(*args)
+      #   ActionView::Helpers::TagHelper.h.tag(*args)
       # end
 
       def locale

--- a/lib/seorel/helper/generic.rb
+++ b/lib/seorel/helper/generic.rb
@@ -10,12 +10,12 @@ module Seorel
       end
 
       def description_tag
-        h.tag :meta, nil, name: 'description', content: params.description
+        h.tag :meta, name: 'description', content: params.description
       end
 
       def keywords_tag
         return if params.keywords.blank?
-        h.tag :meta, nil, name: 'keywords', content: params.keywords
+        h.tag :meta, name: 'keywords', content: params.keywords
       end
 
       def all

--- a/lib/seorel/helper/generic.rb
+++ b/lib/seorel/helper/generic.rb
@@ -10,12 +10,12 @@ module Seorel
       end
 
       def description_tag
-        h.content_tag :meta, nil, name: 'description', content: params.description
+        h.tag :meta, nil, name: 'description', content: params.description
       end
 
       def keywords_tag
         return if params.keywords.blank?
-        h.content_tag :meta, nil, name: 'keywords', content: params.keywords
+        h.tag :meta, nil, name: 'keywords', content: params.keywords
       end
 
       def all

--- a/lib/seorel/helper/open_graph.rb
+++ b/lib/seorel/helper/open_graph.rb
@@ -6,23 +6,23 @@ module Seorel
   module Helper
     class OpenGraph < Base
       def title_tag
-        h.tag :meta, nil, property: 'og:title', content: title
+        h.tag :meta, property: 'og:title', content: title
       end
 
       def description_tag
-        h.tag :meta, nil, property: 'og:description', content: description
+        h.tag :meta, property: 'og:description', content: description
       end
 
       def locale_tag
-        h.tag(:meta, nil, property: 'og:locale', content: locale)
+        h.tag(:meta, property: 'og:locale', content: locale)
       end
 
       def image_tag
-        h.tag(:meta, nil, property: 'og:image', content: image_url) if image
+        h.tag(:meta, property: 'og:image', content: image_url) if image
       end
 
       def url_tag
-        h.tag(:meta, nil, property: 'og:url', content: request.url)
+        h.tag(:meta, property: 'og:url', content: request.url)
       end
 
       def custom_tags
@@ -44,7 +44,7 @@ module Seorel
       protected
 
       def custum_tag(key, value)
-        h.tag(:meta, nil, property: "og:#{key}", content: value)
+        h.tag(:meta, property: "og:#{key}", content: value)
       end
     end
   end

--- a/lib/seorel/helper/open_graph.rb
+++ b/lib/seorel/helper/open_graph.rb
@@ -6,23 +6,23 @@ module Seorel
   module Helper
     class OpenGraph < Base
       def title_tag
-        h.content_tag :meta, nil, property: 'og:title', content: title
+        h.tag :meta, nil, property: 'og:title', content: title
       end
 
       def description_tag
-        h.content_tag :meta, nil, property: 'og:description', content: description
+        h.tag :meta, nil, property: 'og:description', content: description
       end
 
       def locale_tag
-        h.content_tag(:meta, nil, property: 'og:locale', content: locale)
+        h.tag(:meta, nil, property: 'og:locale', content: locale)
       end
 
       def image_tag
-        h.content_tag(:meta, nil, property: 'og:image', content: image_url) if image
+        h.tag(:meta, nil, property: 'og:image', content: image_url) if image
       end
 
       def url_tag
-        h.content_tag(:meta, nil, property: 'og:url', content: request.url)
+        h.tag(:meta, nil, property: 'og:url', content: request.url)
       end
 
       def custom_tags
@@ -44,7 +44,7 @@ module Seorel
       protected
 
       def custum_tag(key, value)
-        h.content_tag(:meta, nil, property: "og:#{key}", content: value)
+        h.tag(:meta, nil, property: "og:#{key}", content: value)
       end
     end
   end

--- a/lib/seorel/helper/twitter.rb
+++ b/lib/seorel/helper/twitter.rb
@@ -6,19 +6,19 @@ module Seorel
   module Helper
     class Twitter < Base
       def title_tag
-        h.tag :meta, nil, name: 'twitter:title', content: title
+        h.tag :meta, name: 'twitter:title', content: title
       end
 
       def description_tag
-        h.tag :meta, nil, name: 'twitter:description', content: description
+        h.tag :meta, name: 'twitter:description', content: description
       end
 
       def image_tag
-        h.tag(:meta, nil, name: 'twitter:image', content: image_url) if image
+        h.tag(:meta, name: 'twitter:image', content: image_url) if image
       end
 
       def url_tag
-        h.tag(:meta, nil, name: 'twitter:url', content: request.url)
+        h.tag(:meta, name: 'twitter:url', content: request.url)
       end
 
       def custom_tags
@@ -39,7 +39,7 @@ module Seorel
       protected
 
       def custum_tag(key, value)
-        h.tag(:meta, nil, name: "twitter:#{key}", content: value)
+        h.tag(:meta, name: "twitter:#{key}", content: value)
       end
     end
   end

--- a/lib/seorel/helper/twitter.rb
+++ b/lib/seorel/helper/twitter.rb
@@ -6,19 +6,19 @@ module Seorel
   module Helper
     class Twitter < Base
       def title_tag
-        h.content_tag :meta, nil, name: 'twitter:title', content: title
+        h.tag :meta, nil, name: 'twitter:title', content: title
       end
 
       def description_tag
-        h.content_tag :meta, nil, name: 'twitter:description', content: description
+        h.tag :meta, nil, name: 'twitter:description', content: description
       end
 
       def image_tag
-        h.content_tag(:meta, nil, name: 'twitter:image', content: image_url) if image
+        h.tag(:meta, nil, name: 'twitter:image', content: image_url) if image
       end
 
       def url_tag
-        h.content_tag(:meta, nil, name: 'twitter:url', content: request.url)
+        h.tag(:meta, nil, name: 'twitter:url', content: request.url)
       end
 
       def custom_tags
@@ -39,7 +39,7 @@ module Seorel
       protected
 
       def custum_tag(key, value)
-        h.content_tag(:meta, nil, name: "twitter:#{key}", content: value)
+        h.tag(:meta, nil, name: "twitter:#{key}", content: value)
       end
     end
   end


### PR DESCRIPTION
use tag helper instead of content_tag helper to avoid non-valid meta tag Stray end. 
